### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/rename_dll.py
+++ b/rename_dll.py
@@ -17,13 +17,13 @@ process = subprocess.Popen(['dumpbin', '/EXPORTS', args.inputdll], stdout=subpro
 out, err = process.communicate()
 
 # get all the function definitions
-lines = out.split('\n')
+lines = out.splitlines(keepends=False)
 pattern = r'^\s*(\d+)\s+[A-Z0-9]+\s+[A-Z0-9]{8}\s+([^ ]+)'
 
 library_output = 'EXPORTS \n'
 
 for line in lines:
-    matches = re.search(pattern, line)
+    matches = re.search(pattern, line.decode('ascii'))
 
     if matches is not None:
         #ordinal = matches.group(1)


### PR DESCRIPTION
Fixes the error (out is bytes in Python 3, and '\n' is not):
```
Traceback (most recent call last):
  File "rename_dll.py", line 20, in <module>
    lines = out.split('\n')
TypeError: a bytes-like object is required, not 'str'
```
and then (re.search doesn't accept bytes):
```
Traceback (most recent call last):
  File "rename_dll.py", line 26, in <module>
    matches = re.search(pattern, line)
  File "C:\Users\User\AppData\Local\Programs\Python\Python36\lib\re.py", line 182, in search
    return _compile(pattern, flags).search(string)
TypeError: cannot use a string pattern on a bytes-like object
```